### PR TITLE
Fix a minor bug in login

### DIFF
--- a/tap/tap.py
+++ b/tap/tap.py
@@ -273,9 +273,9 @@ class TAP_Service(object):
         """
         if password is None:
             import getpass
-            pw = getpass.getpass()
+            password = getpass.getpass()
         r = self.session.post("https://{s.host:s}/tap-server/login".format(s=self),
-                              data={'username': username, 'password':pw})
+                              data={'username': username, 'password':password})
         if not r.ok:
             raise RuntimeError('Authentication failed\n' + str(r))
 
@@ -410,8 +410,8 @@ class GaiaArchive(TAP_Service):
         path = "/tap-server/tap"
         protocol = "https"
         TAP_Service.__init__(self, host, path, port, *args, **kwargs)
-        
-        
+
+
 class GAVO(TAP_Service):
     def __init__(self, *args, **kwargs):
         host = 'dc.zah.uni-heidelberg.de'
@@ -419,7 +419,7 @@ class GAVO(TAP_Service):
         port = 80
         TAP_Service.__init__(self, host, path, port, *args, **kwargs)
 
-        
+
 def resolve(objectName):
         """
         Resolve the object by name using CDS


### PR DESCRIPTION
I think the variable names were mixed up.

```python
>>> gaia.login('user', 'pass')

---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-4-710000572719> in <module>()
----> 1 gaia.login('user', 'pass')

~/projects/opensource/tap/tap/tap.py in login(self, username, password)
    276             pw = getpass.getpass()
    277         r = self.session.post("https://{s.host:s}/tap-server/login".format(s=self),
--> 278                               data={'username': username, 'password':pw})
    279         if not r.ok:
    280             raise RuntimeError('Authentication failed\n' + str(r))

UnboundLocalError: local variable 'pw' referenced before assignment
```